### PR TITLE
Raise PR: feat/screeners -> master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://fyers.in/"><img src="https://assets.fyers.in/images/logo.svg" align="right" /></a>
 
-# Fyers Go SDK : fyers-api-v3 - v1.2.0
+# Fyers Go SDK : fyers-api-v3 - v1.4.0
 
 The official Fyers Go SDK for API-V3 Users [FYERS API](https://fyers.in/products/api/).
 
@@ -309,6 +309,15 @@ All API methods return `(string, error)`; the string is the raw JSON response. U
 | `GetMarketDepth(req MarketDepthRequest) (string, error)` | Market depth (symbol, ohlcv_flag). |
 | `GetOptionChain(req OptionChainRequest) (string, error)` | Options chain. |
 
+### Screeners (FyersModel)
+
+| Method | Description |
+|--------|-------------|
+| `ScreenersConfig() (string, error)` | Screener configuration (available universes, fields, candlestick patterns, technical indicators). |
+| `ScreenersQuery(req *ScreenersQuery) (string, error)` | Custom query screener (`screener`, `universe`, `fields`, `order_by`, `order`). Pass `nil` for no filters. |
+| `ScreenersCandlestick(req *ScreenersCandlestick) (string, error)` | Candlestick pattern screener (`screener`). Pass `nil` for no filters. |
+| `ScreenersTechnical(req *ScreenersTechnical) (string, error)` | Technical indicator screener (`screener`). Pass `nil` for no filters. |
+
 ### Broker (FyersModel)
 
 | Method | Description |
@@ -480,3 +489,10 @@ All runnable examples live in **[examples/fyers/fyers.go](examples/fyers/fyers.g
 - **Market depth** – `GetMarketDepth`
 - **Option Chain** – `GetOptionChain`
 - **Get History** – `GetHistory`
+
+### Screeners
+- **Screeners Config** – `ScreenersConfig`
+- **Screeners Query** – `ScreenersQuery`
+- **Screeners Candlestick** – `ScreenersCandlestick`
+- **Screeners Technical** – `ScreenersTechnical`
+

--- a/api.go
+++ b/api.go
@@ -51,4 +51,8 @@ const (
 	RealisedProfitURL        = BaseURL + "/realised-pnl-history"
 	TaxPnLHistoryURL         = BaseURL + "/tax-pnl-history"
 	LedgerHistoryURL         = BaseURL + "/ledger-history"
+	ScreenersConfigURL       = BaseURL + "/screeners/config"
+	ScreenersQueryURL        = BaseURL + "/screeners/query"
+	ScreenersCandlestickURL  = BaseURL + "/screeners/candlestick"
+	ScreenersTechnicalURL    = BaseURL + "/screeners/technical"
 )

--- a/models.go
+++ b/models.go
@@ -811,3 +811,19 @@ type LedgerHistoryFilter struct {
 	Exchange        []string `json:"exchange_type,omitempty"`
 	Segment         []string `json:"segment_type,omitempty"`
 }
+
+type ScreenersQuery struct {
+	Screener string `json:"screener"`
+	Universe string `json:"universe"`
+	Fields   string `json:"fields"`
+	OrderBy  string `json:"order_by"`
+	Order    string `json:"order"`
+}
+
+type ScreenersCandlestick struct {
+	Screener string `json:"screener"`
+}
+
+type ScreenersTechnical struct {
+	Screener string `json:"screener"`
+}

--- a/screeners.go
+++ b/screeners.go
@@ -1,0 +1,74 @@
+package fyersgosdk
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func (m *FyersModel) ScreenersConfig() (string, error) {
+	resp, err := m.httpClient.Do(
+		http.MethodGet,
+		ScreenersConfigURL,
+		nil,
+		m.authHeader(),
+	)
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Body), nil
+}
+
+func (m *FyersModel) ScreenersQuery(req *ScreenersQuery) (string, error) {
+	params := url.Values{}
+	if req != nil {
+		params.Set("screener", req.Screener)
+		params.Set("universe", req.Universe)
+		params.Set("fields", req.Fields)
+		params.Set("order_by", req.OrderBy)
+		params.Set("order", req.Order)
+	}
+	resp, err := m.httpClient.Do(
+		http.MethodGet,
+		ScreenersQueryURL,
+		params,
+		m.authHeader(),
+	)
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Body), nil
+}
+
+func (m *FyersModel) ScreenersCandlestick(req *ScreenersQuery) (string, error) {
+	params := url.Values{}
+	if req != nil {
+		params.Set("screener", req.Screener)
+	}
+	resp, err := m.httpClient.Do(
+		http.MethodGet,
+		ScreenersCandlestickURL,
+		params,
+		m.authHeader(),
+	)
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Body), nil
+}
+
+func (m *FyersModel) ScreenersTechnical(req *ScreenersQuery) (string, error) {
+	params := url.Values{}
+	if req != nil {
+		params.Set("screener", req.Screener)
+	}
+	resp, err := m.httpClient.Do(
+		http.MethodGet,
+		ScreenersTechnicalURL,
+		params,
+		m.authHeader(),
+	)
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Body), nil
+}

--- a/screeners.go
+++ b/screeners.go
@@ -39,7 +39,7 @@ func (m *FyersModel) ScreenersQuery(req *ScreenersQuery) (string, error) {
 	return string(resp.Body), nil
 }
 
-func (m *FyersModel) ScreenersCandlestick(req *ScreenersQuery) (string, error) {
+func (m *FyersModel) ScreenersCandlestick(req *ScreenersCandlestick) (string, error) {
 	params := url.Values{}
 	if req != nil {
 		params.Set("screener", req.Screener)
@@ -56,7 +56,7 @@ func (m *FyersModel) ScreenersCandlestick(req *ScreenersQuery) (string, error) {
 	return string(resp.Body), nil
 }
 
-func (m *FyersModel) ScreenersTechnical(req *ScreenersQuery) (string, error) {
+func (m *FyersModel) ScreenersTechnical(req *ScreenersTechnical) (string, error) {
 	params := url.Values{}
 	if req != nil {
 		params.Set("screener", req.Screener)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only GET endpoints with no changes to auth, orders, or trading flows; documentation and additive SDK surface only.
> 
> **Overview**
> Adds **Screeners** support to `FyersModel`, exposing config plus query, candlestick, and technical screener calls as authenticated GETs that return raw JSON strings.
> 
> New `/screeners/*` URL constants, request types (`ScreenersQuery`, `ScreenersCandlestick`, `ScreenersTechnical`), and `screeners.go` mirror existing market-data helpers (optional `nil` request → no query params). README is updated to **v1.4.0** with API reference and examples for the four methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d084dfb1908c997a1761f9f4aa97a44e9bea78df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->