### PR TITLE
Raise PR: feat/cobodeprecation -> master

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ func main() {
         ProductType: fyersgosdk.ProductIntraday,
         LimitPrice:  500.0,
         Validity:    "DAY",
-        TakeProfit:  fyersgosdk.FloatOffset(10.5), // optional
-        StopLoss:    fyersgosdk.FloatOffset(5.0),  // optional — omit either field if not needed
+        TakeProfit:  10.5, // optional float
+        StopLoss:    5.0,  // optional float — omit either field (or leave 0) if not needed
         LegType:     fyersgosdk.LegTypePoints, // 1 = points, 2 = percent
     })
     if err != nil {
@@ -169,9 +169,9 @@ func main() {
 
     // Update TP and remove SL on an open order
     mod, err := fyModel.ModifyOrder(fyersgosdk.ModifyOrderRequest{
-        Id:         "23072800012345",
-        TakeProfit: fyersgosdk.FloatOffset(15.0),
-        StopLoss:   fyersgosdk.NullOffset(), // JSON null removes the SL leg
+        Id:            "23072800012345",
+        TakeProfit:    15.0,
+        ClearStopLoss: true, // sends "stopLoss": null
     })
     if err != nil {
         fmt.Println("Error:", err)
@@ -182,8 +182,8 @@ func main() {
     // Attach TP/SL to an open position
     attach, err := fyModel.AttachPositionLegs(fyersgosdk.AttachPositionLegsRequest{
         PositionID: "NSE:SBIN-EQ-INTRADAY",
-        TakeProfit: fyersgosdk.FloatOffset(2.5),
-        StopLoss:   fyersgosdk.FloatOffset(1.5),
+        TakeProfit: 2.5,
+        StopLoss:   1.5,
         LegType:    fyersgosdk.LegTypePercent,
     })
     if err != nil {
@@ -504,7 +504,7 @@ All runnable examples live in **[examples/fyers/fyers.go](examples/fyers/fyers.g
 - **Single Order Placement** – `SingleOrderAction` (supports `takeProfit` / `stopLoss` / `legType` offsets)
 - **Multi Order Placement** – `MultiOrderAction`
 - **MultiLeg Order** – `MultiLegOrderAction`
-- **Modify Orders** – `ModifyOrder` (update/clear TP/SL via `FloatOffset` / `NullOffset`)
+- **Modify Orders** – `ModifyOrder` (update TP/SL via float fields; clear with `ClearTakeProfit` / `ClearStopLoss`)
 - **Modify Multi Orders** – `ModifyMutliOrder`
 - **Cancel Order** – `CancelOrder`
 - **Multi Cancel Order** – `CancelMutliOrder`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Fyers API is a set of REST-like APIs that provide integration with our in-house 
 - **Authentication**: OAuth2-based authentication with automatic token management
 - **Real-time Data**: WebSocket streaming for live market data and order updates
 - **Trading Operations**: Place, modify, and cancel orders with support for various order types
+- **TP/SL Smart Orders**: Attach take-profit / stop-loss offsets on place, modify, or open positions (`BO`/`CO` deprecated)
 - **Portfolio Management**: Access holdings, positions, and fund information
 - **Market Data**: Historical data, real-time quotes, market depth, and options chain
 - **Error Handling**: Comprehensive error handling with detailed error messages
@@ -129,6 +130,67 @@ func main() {
         LimitPrice: 100, Validity: "DAY", DisclosedQty: 0, OfflineOrder: false,
     })
     fmt.Println("Response:", response)
+}
+```
+
+### Place an Order with TP/SL (offsets)
+
+TP/SL values are **optional offsets** (points or percent of entry), not absolute prices. Set `takeProfit`, `stopLoss`, both, or neither. Use standard product types (`CNC`, `INTRADAY`, `MARGIN`, `MTF`) — `BO` / `CO` are deprecated and rejected by the API.
+
+```go
+package main
+
+import (
+    "fmt"
+    fyersgosdk "github.com/FyersDev/fyers-go-sdk"
+)
+
+func main() {
+    fyModel := fyersgosdk.NewFyersModel("AAAAAAAAA-100", "eyjb....")
+
+    // Place with take-profit / stop-loss overlays (sync endpoint only)
+    response, err := fyModel.SingleOrderAction(fyersgosdk.OrderRequest{
+        Symbol:      "NSE:SBIN-EQ",
+        Qty:         10,
+        Type:        1,
+        Side:        1,
+        ProductType: fyersgosdk.ProductIntraday,
+        LimitPrice:  500.0,
+        Validity:    "DAY",
+        TakeProfit:  fyersgosdk.FloatOffset(10.5), // optional
+        StopLoss:    fyersgosdk.FloatOffset(5.0),  // optional — omit either field if not needed
+        LegType:     fyersgosdk.LegTypePoints, // 1 = points, 2 = percent
+    })
+    if err != nil {
+        fmt.Println("Error:", err)
+        return
+    }
+    fmt.Println("Response:", response)
+
+    // Update TP and remove SL on an open order
+    mod, err := fyModel.ModifyOrder(fyersgosdk.ModifyOrderRequest{
+        Id:         "23072800012345",
+        TakeProfit: fyersgosdk.FloatOffset(15.0),
+        StopLoss:   fyersgosdk.NullOffset(), // JSON null removes the SL leg
+    })
+    if err != nil {
+        fmt.Println("Error:", err)
+        return
+    }
+    fmt.Println("Modify:", mod)
+
+    // Attach TP/SL to an open position
+    attach, err := fyModel.AttachPositionLegs(fyersgosdk.AttachPositionLegsRequest{
+        PositionID: "NSE:SBIN-EQ-INTRADAY",
+        TakeProfit: fyersgosdk.FloatOffset(2.5),
+        StopLoss:   fyersgosdk.FloatOffset(1.5),
+        LegType:    fyersgosdk.LegTypePercent,
+    })
+    if err != nil {
+        fmt.Println("Error:", err)
+        return
+    }
+    fmt.Println("Attach:", attach)
 }
 ```
 
@@ -275,7 +337,7 @@ All API methods return `(string, error)`; the string is the raw JSON response. U
 | `SingleOrderAction(orderRequest OrderRequest) (string, error)` | Place single order. |
 | `MultiOrderAction(orderRequests []OrderRequest) (string, error)` | Place multiple orders. |
 | `MultiLegOrderAction(orderRequests []MultiLegOrderRequest) (string, error)` | Place multi-leg orders. |
-| `ModifyOrder(orderRequest ModifyOrderRequest) (string, error)` | Modify single order (PATCH). |
+| `ModifyOrder(orderRequest ModifyOrderRequest) (string, error)` | Modify single order (PATCH). Supports optional `takeProfit` / `stopLoss` / `legType`. |
 | `ModifyMutliOrder(requests []ModifyMultiOrderItem) (string, error)` | Modify multiple orders (PATCH). |
 | `CancelOrder(Id string) (string, error)` | Cancel single order. |
 | `CancelMutliOrder(orderIds []string) (string, error)` | Cancel multiple orders (DELETE). |
@@ -299,6 +361,7 @@ All API methods return `(string, error)`; the string is the raw JSON response. U
 | `ExitPositionByProductType(req ExitPositionByProductTypeRequest) (string, error)` | Exit by segment/side/productType. |
 | `CancelPendingOrders(req CancelPendingOrdersRequest) (string, error)` | Cancel pending orders (optional Id for single symbol). |
 | `ConvertPosition(req ConvertPositionRequest) (string, error)` | Convert position (e.g. INTRADAY to CNC). |
+| `AttachPositionLegs(req AttachPositionLegsRequest) (string, error)` | Attach/update/remove TP/SL legs on an open position (PATCH). |
 
 ### Market Data (FyersModel)
 
@@ -438,10 +501,10 @@ All runnable examples live in **[examples/fyers/fyers.go](examples/fyers/fyers.g
 - **Get Positions** – `GetPositions`
 
 ### Orders
-- **Single Order Placement** – `SingleOrderAction`
+- **Single Order Placement** – `SingleOrderAction` (supports `takeProfit` / `stopLoss` / `legType` offsets)
 - **Multi Order Placement** – `MultiOrderAction`
 - **MultiLeg Order** – `MultiLegOrderAction`
-- **Modify Orders** – `ModifyOrder`
+- **Modify Orders** – `ModifyOrder` (update/clear TP/SL via `FloatOffset` / `NullOffset`)
 - **Modify Multi Orders** – `ModifyMutliOrder`
 - **Cancel Order** – `CancelOrder`
 - **Multi Cancel Order** – `CancelMutliOrder`
@@ -475,7 +538,7 @@ All runnable examples live in **[examples/fyers/fyers.go](examples/fyers/fyers.g
 - **Exit Position by Tag** – `ExitPositionByProductType`
 - **Pending Order Cancel** – `CancelPendingOrders`
 - **Convert Position** – `ConvertPosition`
-
+- **Attach Position TP/SL Legs** – `AttachPositionLegs`
 ### Alerts
 - **Create Price Alert** – `CreateAlert`
 - **Get Price Alerts** – `GetAlerts`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://fyers.in/"><img src="https://assets.fyers.in/images/logo.svg" align="right" /></a>
 
-# Fyers Go SDK : fyers-api-v3 - v1.4.0
+# Fyers Go SDK : fyers-api-v3 - v1.5.0
 
 The official Fyers Go SDK for API-V3 Users [FYERS API](https://fyers.in/products/api/).
 

--- a/constants.go
+++ b/constants.go
@@ -23,9 +23,3 @@ const (
 	// LegTypePercent measures takeProfit/stopLoss as a percentage of entry price.
 	LegTypePercent = 2
 )
-
-const (
-	minTPSLOffset      = 0.0025
-	maxTPSLPercent     = 100.0
-	deprecatedBOCOCode = -1800
-)

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,31 @@
+package fyersgosdk
+
+// Product type constants for order placement.
+const (
+	ProductCNC      = "CNC"
+	ProductIntraday = "INTRADAY"
+	ProductMargin   = "MARGIN"
+	ProductMTF      = "MTF"
+
+	// Deprecated: ProductBO is deprecated and rejected by the API (HTTP 400, code -1800).
+	// Use ProductIntraday or ProductMargin with TakeProfit/StopLoss offsets instead.
+	ProductBO = "BO"
+
+	// Deprecated: ProductCO is deprecated and rejected by the API (HTTP 400, code -1800).
+	// Use a standard product type with TakeProfit/StopLoss offsets instead.
+	ProductCO = "CO"
+)
+
+// LegType values for TP/SL offset measurement.
+const (
+	// LegTypePoints measures takeProfit/stopLoss as price-point offsets (default).
+	LegTypePoints = 1
+	// LegTypePercent measures takeProfit/stopLoss as a percentage of entry price.
+	LegTypePercent = 2
+)
+
+const (
+	minTPSLOffset      = 0.0025
+	maxTPSLPercent     = 100.0
+	deprecatedBOCOCode = -1800
+)

--- a/constants.go
+++ b/constants.go
@@ -6,14 +6,6 @@ const (
 	ProductIntraday = "INTRADAY"
 	ProductMargin   = "MARGIN"
 	ProductMTF      = "MTF"
-
-	// Deprecated: ProductBO is deprecated and rejected by the API (HTTP 400, code -1800).
-	// Use ProductIntraday or ProductMargin with TakeProfit/StopLoss offsets instead.
-	ProductBO = "BO"
-
-	// Deprecated: ProductCO is deprecated and rejected by the API (HTTP 400, code -1800).
-	// Use a standard product type with TakeProfit/StopLoss offsets instead.
-	ProductCO = "CO"
 )
 
 // LegType values for TP/SL offset measurement.

--- a/examples/fyers/fyers.go
+++ b/examples/fyers/fyers.go
@@ -279,30 +279,32 @@ import (
 // }
 
 // Single Order Placement
-// func main() {
-// 	appId := "AAAAAAAAA-100"
-// 	accessToken := "eyjb...."
+func main() {
+	appId := "DSBF1SDSUE-200"
+	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsieDowIiwieDoxIiwieDoyIl0sImF0X2hhc2giOiJnQUFBQUFCcWJHQVExVWZnUVo2N25aWFFsT0FPWnctWmtWSEFSZGtwSEctLW15em5keks1QVhIWmJfMWh2U1REaTU4SGJWalJ5dXJGNEFCZ3psLS0wSC16MUVUdmNDY01pQjhxZ0pObE9LZXQ2RDYzYjlaV3JwOD0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiIwZjE1Y2U4OGQyNzVmODY3OTUxY2ZhZmZkZGNiMDg2M2Y5ZjY1MWNlZDdkYjllODcxODY0MDQxOSIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiWSIsImZ5X2lkIjoiWFIwMDgzOSIsImFwcFR5cGUiOjIwMCwiZXhwIjoxNzg1NTQ0MjAwLCJpYXQiOjE3ODU0ODczNzYsImlzcyI6ImFwaS5meWVycy5jby5pbiIsIm5iZiI6MTc4NTQ4NzM3Niwic3ViIjoiYWNjZXNzX3Rva2VuIn0.7AKP0K8K2hWbq9ruBFGXiYVp-GqLJhxKt6N59UoGfmY"
 
-// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
-// 	response, err := fyModel.SingleOrderAction(fyersgosdk.OrderRequest{
-// 		Symbol:       "NSE:IDEA-EQ",
-// 		Qty:          1,
-// 		Type:         1,
-// 		Side:         1,
-// 		ProductType:  fyersgosdk.ProductCNC,
-// 		LimitPrice:   100,
-// 		StopPrice:    0,
-// 		Validity:     "DAY",
-// 		DisclosedQty: 1,
-// 		OfflineOrder: false,
-// 		OrderTag:     "TESTEST",
-// 	})
-// 	if err != nil {
-// 		fmt.Printf("Error single order action: %v", err)
-// 	} else {
-// 		fmt.Println("single order action: ", response)
-// 	}
-// }
+	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+	response, err := fyModel.SingleOrderAction(fyersgosdk.OrderRequest{
+		Symbol:       "NSE:IDEA-EQ",
+		Qty:          1,
+		Type:         1,
+		Side:         1,
+		ProductType:  "CO",
+		LimitPrice:   12,
+		StopPrice:    0,
+		Validity:     "DAY",
+		DisclosedQty: 1,
+		OfflineOrder: false,
+		OrderTag:     "TESTEST",
+		TakeProfit:   -10.5, // optional float
+		StopLoss:     5.0,   // optional float
+	})
+	if err != nil {
+		fmt.Printf("Error single order action: %v", err)
+	} else {
+		fmt.Println("single order action: ", response)
+	}
+}
 
 // Single Order Placement with TP/SL offsets (replaces deprecated BO/CO)
 // func main() {
@@ -318,8 +320,8 @@ import (
 // 		ProductType:  fyersgosdk.ProductIntraday,
 // 		LimitPrice:   500.0,
 // 		Validity:     "DAY",
-// 		TakeProfit:   fyersgosdk.FloatOffset(10.5), // optional
-// 		StopLoss:     fyersgosdk.FloatOffset(5.0),  // optional
+// 		TakeProfit:   10.5, // optional float
+// 		StopLoss:     5.0,  // optional float
 // 		LegType:      fyersgosdk.LegTypePoints,
 // 		OrderTag:     "TPSL",
 // 	})
@@ -534,8 +536,8 @@ import (
 // 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 // 	response, err := fyModel.ModifyOrder(fyersgosdk.ModifyOrderRequest{
 // 		Id:         "23072800012345",
-// 		TakeProfit: fyersgosdk.FloatOffset(15.0),
-// 		StopLoss:   fyersgosdk.NullOffset(),
+// 		TakeProfit:    15.0,
+// 		ClearStopLoss: true, // sends "stopLoss": null
 // 	})
 // 	if err != nil {
 // 		fmt.Printf("Error modify order TP/SL: %v", err)
@@ -684,8 +686,8 @@ import (
 // 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 // 	response, err := fyModel.AttachPositionLegs(fyersgosdk.AttachPositionLegsRequest{
 // 		PositionID: "NSE:SBIN-EQ-INTRADAY",
-// 		TakeProfit: fyersgosdk.FloatOffset(2.5),
-// 		StopLoss:   fyersgosdk.FloatOffset(1.5),
+// 		TakeProfit: 2.5,
+// 		StopLoss:   1.5,
 // 		LegType:    fyersgosdk.LegTypePercent,
 // 	})
 // 	if err != nil {
@@ -1209,20 +1211,38 @@ import (
 // }
 
 // option chain
-func main() {
-	appId := "GT2V66D5Y4-101"
-	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsieDowIl0sImF0X2hhc2giOiJnQUFBQUFCcDF6ZXl3bFdqMXlFd3dfa0lHSzBDcGJBbWFTWFdsY0RNdkpMTkxiX2pmOXhMaGpzVjJCQzZUZDdfSDA1dzZvUnlXRzdqMGdmSEI3S29mRlVsUVJHNGxuU2QwSE5WM1VWRnVkYzRZaFVETkxtb2FsND0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiJjZGE1NGVmMDU1NGYzMmFjOTg2NWViNzMxMGNiMzk1ZmRiYTc1MTY5ZTY3NWNjZjc3OWJjMDM0ZCIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiWSIsImZ5X2lkIjoiRkFGNTA2NzUiLCJhcHBUeXBlIjoxMDEsImV4cCI6MTc3NTc4MTAwMCwiaWF0IjoxNzc1NzEyMTc4LCJpc3MiOiJhcGkuZnllcnMuaW4iLCJuYmYiOjE3NzU3MTIxNzgsInN1YiI6ImFjY2Vzc190b2tlbiJ9.hNoVAtbeD8-i8bRLTDEUjKppMVnQ9ERaPNTafEMAb0U"
-	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+// func main() {
+// 	appId := "GT2V66D5Y4-101"
+// 	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsieDowIl0sImF0X2hhc2giOiJnQUFBQUFCcDF6ZXl3bFdqMXlFd3dfa0lHSzBDcGJBbWFTWFdsY0RNdkpMTkxiX2pmOXhMaGpzVjJCQzZUZDdfSDA1dzZvUnlXRzdqMGdmSEI3S29mRlVsUVJHNGxuU2QwSE5WM1VWRnVkYzRZaFVETkxtb2FsND0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiJjZGE1NGVmMDU1NGYzMmFjOTg2NWViNzMxMGNiMzk1ZmRiYTc1MTY5ZTY3NWNjZjc3OWJjMDM0ZCIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiWSIsImZ5X2lkIjoiRkFGNTA2NzUiLCJhcHBUeXBlIjoxMDEsImV4cCI6MTc3NTc4MTAwMCwiaWF0IjoxNzc1NzEyMTc4LCJpc3MiOiJhcGkuZnllcnMuaW4iLCJuYmYiOjE3NzU3MTIxNzgsInN1YiI6ImFjY2Vzc190b2tlbiJ9.hNoVAtbeD8-i8bRLTDEUjKppMVnQ9ERaPNTafEMAb0U"
+// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 
-	response, err := fyModel.GetOptionChain(fyersgosdk.OptionChainRequest{
-		Symbol:      "NSE:TCS-EQ",
-		StrikeCount: 1,
-		Timestamp:   "", // optional
-		Greeks:      "1",
-	})
-	if err != nil {
-		fmt.Printf("Error getting option chain: %v", err)
-	} else {
-		fmt.Println("Option chain: ", response)
-	}
-}
+// 	response, err := fyModel.GetOptionChain(fyersgosdk.OptionChainRequest{
+// 		Symbol:      "NSE:TCS-EQ",
+// 		StrikeCount: 1,
+// 		Timestamp:   "", // optional
+// 		Greeks:      "1",
+// 	})
+// 	if err != nil {
+// 		fmt.Printf("Error getting option chain: %v", err)
+// 	} else {
+// 		fmt.Println("Option chain: ", response)
+// 	}
+// }
+
+// func main() {
+// 	appId := "BQ6KVNTLF1-200"
+// 	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiZDoxIiwiZDoyIiwieDowIiwieDoxIiwieDoyIl0sImF0X2hhc2giOiJnQUFBQUFCcWJDeFd3MFlselBLeEJMQzNlUk9NMHRlLXBoS1V1WjQyRWg5NDBGMGJDbjBQajZDanJwOGtoanJiZnJBSmtZbVN0U2xoUkxod0UyekZtb3RtZ2drT0U3OWp3VHU5TGVMTWlXNDNuNmZuU0l1ZGZLOD0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiI5ZTAyMTQxNjMwYmZmZjRjZDk0NzMyMDkzZWQwNTUwYzY2NGIxNDI5NzE3YzMzZTJhZmI4MDVmOSIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiTiIsImZ5X2lkIjoiWFIyNDc2MSIsImFwcFR5cGUiOjIwMCwiZXhwIjoxNzg1NTQ0MjAwLCJpYXQiOjE3ODU0NzQxMzQsImlzcyI6ImFwaS5meWVycy5jby5pbiIsIm5iZiI6MTc4NTQ3NDEzNCwic3ViIjoiYWNjZXNzX3Rva2VuIn0.8jDhWrJMNDYy7swiDKTwdJEvdN4q0M_JNU_8If82dC4"
+// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+
+// 	response, err := fyModel.AttachPositionLegs(fyersgosdk.AttachPositionLegsRequest{
+// 		PositionID: "NSE:IDEA-EQ-CNC",
+// 		TakeProfit: 1,
+// 		StopLoss:   2,
+// 		LegType:    fyersgosdk.LegTypePoints,
+// 	})
+// 	if err != nil {
+// 		fmt.Printf("Error attach position legs: %v", err)
+// 	} else {
+// 		fmt.Println("Attach position legs: ", response)
+// 	}
+// }

--- a/examples/fyers/fyers.go
+++ b/examples/fyers/fyers.go
@@ -1,14 +1,11 @@
 package main
 
-import (
-	"fmt"
-	// "os"
-	// "os/signal"
-	// "syscall"
+// "os"
+// "os/signal"
+// "syscall"
 
-	fyersgosdk "github.com/FyersDev/fyers-go-sdk"
-	// fyersws "github.com/FyersDev/fyers-go-sdk/websocket"
-)
+// fyersgosdk "github.com/FyersDev/fyers-go-sdk"
+// fyersws "github.com/FyersDev/fyers-go-sdk/websocket"
 
 // Get Auth Code URL
 // func main() {
@@ -25,7 +22,7 @@ import (
 // 	appId := "AAAAAAAAA-100"
 // 	appSecret := "XY..."
 // 	redirectUrl := "https://trade.fyers.in/api-login/redirect-uri/index.html"
-// 	authToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBfaWQiOiJNMFI0V1cxUFlVIiwidXVpZCI6IjRkYWU5MjQ0NmY4MDRlMWM5Y2RhNjE5NmU0MmY0MjE0IiwiaXBBZGRyIjoiIiwibm9uY2UiOiIiLCJzY29wZSI6IiIsImRpc3BsYXlfbmFtZSI6IllLMDQzOTEiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiJkNWU1YWY5ZmM0NWMwMzZhY2FkZmE2M2ZhZDc1YzZhMmEwZjc3ZDRmMDFlMWJkMTNlMTc4YWI3YyIsImlzRGRwaUVuYWJsZWQiOiJZIiwiaXNNdGZFbmFibGVkIjoiWSIsImF1ZCI6IltcImQ6MVwiLFwiZDoyXCIsXCJ4OjBcIixcIng6MVwiLFwieDoyXCJdIiwiZXhwIjoxNzcxNDIyMDMwLCJpYXQiOjE3NzEzOTIwMzAsImlzcyI6ImFwaS5sb2dpbi5meWVycy5pbiIsIm5iZiI6MTc3MTM5MjAzMCwic3ViIjoiYXV0aF9jb2RlIn0.rnEMaa8MigGEs_LSwEGoc-y0UbqjVRIwahvVccssMwU"
+// 	authToken := "eyjb...."
 
 // 		fyClient := fyersgosdk.SetClientData(appId, appSecret, redirectUrl)
 // 		response, err := fyClient.GenerateAccessToken(authToken, fyClient)
@@ -40,7 +37,7 @@ import (
 // 	appId := "AAAAAAAAA-100"
 // 	appSecret := "XY..."
 // 	redirectUrl := "https://trade.fyers.in/api-login/redirect-uri/index.html"
-// 	refreshToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiZDoxIiwiZDoyIiwieDowIiwieDoxIiwieDoyIl0sImF0X2hhc2giOiJnQUFBQUFCcGxVNE1xZUpQUFdYNWhWQzcyNkZQVTVXTHpjcFRXMjQ3OGFDdGJMemwybE42TmkzUEZpU0xKMHVDRldPVE9Fc3JIbjVlbWxVdVNiQ2F2UXlySTh0LXozeFdaWFo4MFRXZWFxb0JKeVdtbFFfYVNacz0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiJkNWU1YWY5ZmM0NWMwMzZhY2FkZmE2M2ZhZDc1YzZhMmEwZjc3ZDRmMDFlMWJkMTNlMTc4YWI3YyIsImlzRGRwaUVuYWJsZWQiOiJZIiwiaXNNdGZFbmFibGVkIjoiWSIsImZ5X2lkIjoiWUswNDM5MSIsImFwcFR5cGUiOjEwMCwiZXhwIjoxNzcyNjcwNjAwLCJpYXQiOjE3NzEzOTI1MjQsImlzcyI6ImFwaS5meWVycy5pbiIsIm5iZiI6MTc3MTM5MjUyNCwic3ViIjoicmVmcmVzaF90b2tlbiJ9.ogZNRYM6lWQ4RRpVeOMuzpwmbAK9MLhPB89UBaFtxCY"
+// 	refreshToken := "eyjb...."
 // 	pin := "0000"
 
 // 	fyClient := fyersgosdk.SetClientData(appId, appSecret, redirectUrl)
@@ -167,7 +164,6 @@ import (
 // func main() {
 // 	appId := "AAAAAAAAA-100"
 // 	accessToken := "eyjb...."
-
 // 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 // 	response, err := fyModel.GetPositions()
 // 	if err != nil {
@@ -279,32 +275,32 @@ import (
 // }
 
 // Single Order Placement
-func main() {
-	appId := "DSBF1SDSUE-200"
-	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsieDowIiwieDoxIiwieDoyIl0sImF0X2hhc2giOiJnQUFBQUFCcWJHQVExVWZnUVo2N25aWFFsT0FPWnctWmtWSEFSZGtwSEctLW15em5keks1QVhIWmJfMWh2U1REaTU4SGJWalJ5dXJGNEFCZ3psLS0wSC16MUVUdmNDY01pQjhxZ0pObE9LZXQ2RDYzYjlaV3JwOD0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiIwZjE1Y2U4OGQyNzVmODY3OTUxY2ZhZmZkZGNiMDg2M2Y5ZjY1MWNlZDdkYjllODcxODY0MDQxOSIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiWSIsImZ5X2lkIjoiWFIwMDgzOSIsImFwcFR5cGUiOjIwMCwiZXhwIjoxNzg1NTQ0MjAwLCJpYXQiOjE3ODU0ODczNzYsImlzcyI6ImFwaS5meWVycy5jby5pbiIsIm5iZiI6MTc4NTQ4NzM3Niwic3ViIjoiYWNjZXNzX3Rva2VuIn0.7AKP0K8K2hWbq9ruBFGXiYVp-GqLJhxKt6N59UoGfmY"
+// func main() {
+// 	appId := "AAAAAAAAA-100"
+// 	accessToken := "eyjb...."
 
-	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
-	response, err := fyModel.SingleOrderAction(fyersgosdk.OrderRequest{
-		Symbol:       "NSE:IDEA-EQ",
-		Qty:          1,
-		Type:         1,
-		Side:         1,
-		ProductType:  "CO",
-		LimitPrice:   12,
-		StopPrice:    0,
-		Validity:     "DAY",
-		DisclosedQty: 1,
-		OfflineOrder: false,
-		OrderTag:     "TESTEST",
-		TakeProfit:   -10.5, // optional float
-		StopLoss:     5.0,   // optional float
-	})
-	if err != nil {
-		fmt.Printf("Error single order action: %v", err)
-	} else {
-		fmt.Println("single order action: ", response)
-	}
-}
+// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+// 	response, err := fyModel.SingleOrderAction(fyersgosdk.OrderRequest{
+// 		Symbol:       "NSE:IDEA-EQ",
+// 		Qty:          1,
+// 		Type:         1,
+// 		Side:         1,
+// 		ProductType:  fyersgosdk.ProductCNC,
+// 		LimitPrice:   12,
+// 		StopPrice:    0,
+// 		Validity:     "DAY",
+// 		DisclosedQty: 1,
+// 		OfflineOrder: false,
+// 		OrderTag:     "TESTEST",
+// 		TakeProfit:   10.5, // optional float
+// 		StopLoss:     5.0,  // optional float
+// 	})
+// 	if err != nil {
+// 		fmt.Printf("Error single order action: %v", err)
+// 	} else {
+// 		fmt.Println("single order action: ", response)
+// 	}
+// }
 
 // Single Order Placement with TP/SL offsets (replaces deprecated BO/CO)
 // func main() {
@@ -1212,8 +1208,8 @@ func main() {
 
 // option chain
 // func main() {
-// 	appId := "GT2V66D5Y4-101"
-// 	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsieDowIl0sImF0X2hhc2giOiJnQUFBQUFCcDF6ZXl3bFdqMXlFd3dfa0lHSzBDcGJBbWFTWFdsY0RNdkpMTkxiX2pmOXhMaGpzVjJCQzZUZDdfSDA1dzZvUnlXRzdqMGdmSEI3S29mRlVsUVJHNGxuU2QwSE5WM1VWRnVkYzRZaFVETkxtb2FsND0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiJjZGE1NGVmMDU1NGYzMmFjOTg2NWViNzMxMGNiMzk1ZmRiYTc1MTY5ZTY3NWNjZjc3OWJjMDM0ZCIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiWSIsImZ5X2lkIjoiRkFGNTA2NzUiLCJhcHBUeXBlIjoxMDEsImV4cCI6MTc3NTc4MTAwMCwiaWF0IjoxNzc1NzEyMTc4LCJpc3MiOiJhcGkuZnllcnMuaW4iLCJuYmYiOjE3NzU3MTIxNzgsInN1YiI6ImFjY2Vzc190b2tlbiJ9.hNoVAtbeD8-i8bRLTDEUjKppMVnQ9ERaPNTafEMAb0U"
+// 	appId := "AAAAAAAAA-100"
+// 	accessToken := "eyjb...."
 // 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 
 // 	response, err := fyModel.GetOptionChain(fyersgosdk.OptionChainRequest{
@@ -1229,13 +1225,14 @@ func main() {
 // 	}
 // }
 
+// Attach TP/SL legs to an open position
 // func main() {
-// 	appId := "BQ6KVNTLF1-200"
-// 	accessToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiZDoxIiwiZDoyIiwieDowIiwieDoxIiwieDoyIl0sImF0X2hhc2giOiJnQUFBQUFCcWJDeFd3MFlselBLeEJMQzNlUk9NMHRlLXBoS1V1WjQyRWg5NDBGMGJDbjBQajZDanJwOGtoanJiZnJBSmtZbVN0U2xoUkxod0UyekZtb3RtZ2drT0U3OWp3VHU5TGVMTWlXNDNuNmZuU0l1ZGZLOD0iLCJkaXNwbGF5X25hbWUiOiIiLCJvbXMiOiJLMSIsImhzbV9rZXkiOiI5ZTAyMTQxNjMwYmZmZjRjZDk0NzMyMDkzZWQwNTUwYzY2NGIxNDI5NzE3YzMzZTJhZmI4MDVmOSIsImlzRGRwaUVuYWJsZWQiOiJOIiwiaXNNdGZFbmFibGVkIjoiTiIsImZ5X2lkIjoiWFIyNDc2MSIsImFwcFR5cGUiOjIwMCwiZXhwIjoxNzg1NTQ0MjAwLCJpYXQiOjE3ODU0NzQxMzQsImlzcyI6ImFwaS5meWVycy5jby5pbiIsIm5iZiI6MTc4NTQ3NDEzNCwic3ViIjoiYWNjZXNzX3Rva2VuIn0.8jDhWrJMNDYy7swiDKTwdJEvdN4q0M_JNU_8If82dC4"
+// 	appId := "AAAAAAAAA-100"
+// 	accessToken := "eyjb...."
 // 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 
 // 	response, err := fyModel.AttachPositionLegs(fyersgosdk.AttachPositionLegsRequest{
-// 		PositionID: "NSE:IDEA-EQ-CNC",
+// 		PositionID: "NSE:IDEA-EQ-INTRADAY",
 // 		TakeProfit: 1,
 // 		StopLoss:   2,
 // 		LegType:    fyersgosdk.LegTypePoints,

--- a/examples/fyers/fyers.go
+++ b/examples/fyers/fyers.go
@@ -289,15 +289,39 @@ import (
 // 		Qty:          1,
 // 		Type:         1,
 // 		Side:         1,
-// 		ProductType:  "CNC",
+// 		ProductType:  fyersgosdk.ProductCNC,
 // 		LimitPrice:   100,
 // 		StopPrice:    0,
 // 		Validity:     "DAY",
 // 		DisclosedQty: 1,
 // 		OfflineOrder: false,
-// 		StopLoss:     0,
-// 		TakeProfit:   0,
 // 		OrderTag:     "TESTEST",
+// 	})
+// 	if err != nil {
+// 		fmt.Printf("Error single order action: %v", err)
+// 	} else {
+// 		fmt.Println("single order action: ", response)
+// 	}
+// }
+
+// Single Order Placement with TP/SL offsets (replaces deprecated BO/CO)
+// func main() {
+// 	appId := "AAAAAAAAA-100"
+// 	accessToken := "eyjb...."
+
+// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+// 	response, err := fyModel.SingleOrderAction(fyersgosdk.OrderRequest{
+// 		Symbol:       "NSE:SBIN-EQ",
+// 		Qty:          10,
+// 		Type:         1,
+// 		Side:         1,
+// 		ProductType:  fyersgosdk.ProductIntraday,
+// 		LimitPrice:   500.0,
+// 		Validity:     "DAY",
+// 		TakeProfit:   fyersgosdk.FloatOffset(10.5), // optional
+// 		StopLoss:     fyersgosdk.FloatOffset(5.0),  // optional
+// 		LegType:      fyersgosdk.LegTypePoints,
+// 		OrderTag:     "TPSL",
 // 	})
 // 	if err != nil {
 // 		fmt.Printf("Error single order action: %v", err)
@@ -313,9 +337,9 @@ import (
 
 // 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
 // 	response, err := fyModel.MultiOrderAction([]fyersgosdk.OrderRequest{
-// 		{Symbol: "NSE:ITC-EQ", Qty: 1, Type: 1, Side: 1, ProductType: "CNC", LimitPrice: 165, StopPrice: 0, DisclosedQty: 0, Validity: "DAY", OfflineOrder: true, StopLoss: 0, TakeProfit: 0, OrderTag: "tag1"},
-// 		{Symbol: "NSE:ITC-EQ", Qty: 1, Type: 1, Side: 1, ProductType: "CNC", LimitPrice: 165, StopPrice: 0, DisclosedQty: 0, Validity: "DAY", OfflineOrder: true, StopLoss: 0, TakeProfit: 0, OrderTag: "tag1"},
-// 		{Symbol: "NSE:ITC-EQ", Qty: 1, Type: 1, Side: 1, ProductType: "CNC", LimitPrice: 165, StopPrice: 0, DisclosedQty: 0, Validity: "DAY", OfflineOrder: true, StopLoss: 0, TakeProfit: 0, OrderTag: "tag1"},
+// 		{Symbol: "NSE:ITC-EQ", Qty: 1, Type: 1, Side: 1, ProductType: fyersgosdk.ProductCNC, LimitPrice: 165, StopPrice: 0, DisclosedQty: 0, Validity: "DAY", OfflineOrder: true, OrderTag: "tag1"},
+// 		{Symbol: "NSE:ITC-EQ", Qty: 1, Type: 1, Side: 1, ProductType: fyersgosdk.ProductCNC, LimitPrice: 165, StopPrice: 0, DisclosedQty: 0, Validity: "DAY", OfflineOrder: true, OrderTag: "tag1"},
+// 		{Symbol: "NSE:ITC-EQ", Qty: 1, Type: 1, Side: 1, ProductType: fyersgosdk.ProductCNC, LimitPrice: 165, StopPrice: 0, DisclosedQty: 0, Validity: "DAY", OfflineOrder: true, OrderTag: "tag1"},
 // 	})
 // 	if err != nil {
 // 		fmt.Printf("Error multi order action: %v", err)
@@ -502,6 +526,24 @@ import (
 // 	}
 // }
 
+// Modify Order TP/SL (update takeProfit, remove stopLoss)
+// func main() {
+// 	appId := "AAAAAAAAA-100"
+// 	accessToken := "eyjb...."
+
+// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+// 	response, err := fyModel.ModifyOrder(fyersgosdk.ModifyOrderRequest{
+// 		Id:         "23072800012345",
+// 		TakeProfit: fyersgosdk.FloatOffset(15.0),
+// 		StopLoss:   fyersgosdk.NullOffset(),
+// 	})
+// 	if err != nil {
+// 		fmt.Printf("Error modify order TP/SL: %v", err)
+// 	} else {
+// 		fmt.Println("modify order TP/SL: ", response)
+// 	}
+// }
+
 // Modify Multi Orders
 // func main() {
 // 	appId := "AAAAAAAAA-100"
@@ -631,6 +673,25 @@ import (
 // 		fmt.Printf("Error convert position: %v", err)
 // 	} else {
 // 		fmt.Println("Convert position: ", response)
+// 	}
+// }
+
+// Attach TP/SL legs to an open position
+// func main() {
+// 	appId := "AAAAAAAAA-100"
+// 	accessToken := "eyjb...."
+
+// 	fyModel := fyersgosdk.NewFyersModel(appId, accessToken)
+// 	response, err := fyModel.AttachPositionLegs(fyersgosdk.AttachPositionLegsRequest{
+// 		PositionID: "NSE:SBIN-EQ-INTRADAY",
+// 		TakeProfit: fyersgosdk.FloatOffset(2.5),
+// 		StopLoss:   fyersgosdk.FloatOffset(1.5),
+// 		LegType:    fyersgosdk.LegTypePercent,
+// 	})
+// 	if err != nil {
+// 		fmt.Printf("Error attach position legs: %v", err)
+// 	} else {
+// 		fmt.Println("Attach position legs: ", response)
 // 	}
 // }
 

--- a/models.go
+++ b/models.go
@@ -238,12 +238,10 @@ type OrderRequest struct {
 	Validity     string  `json:"validity"`
 	DisclosedQty int     `json:"disclosedQty"`
 	OfflineOrder bool    `json:"offlineOrder"`
-	// TakeProfit is optional. Offset (points or percent), not an absolute price. Minimum 0.0025.
-	// Omit to place without a TP leg. Use FloatOffset(v) to set.
-	TakeProfit *FloatValue `json:"takeProfit,omitempty"`
-	// StopLoss is optional. Offset (points or percent), not an absolute price. Minimum 0.0025.
-	// Omit to place without an SL leg. Use FloatOffset(v) to set.
-	StopLoss *FloatValue `json:"stopLoss,omitempty"`
+	// TakeProfit is optional. Offset (points or percent), not an absolute price. 0 / omitted = no TP leg.
+	TakeProfit float64 `json:"takeProfit,omitempty"`
+	// StopLoss is optional. Offset (points or percent), not an absolute price. 0 / omitted = no SL leg.
+	StopLoss float64 `json:"stopLoss,omitempty"`
 	// LegType is optional. 1 = points (default), 2 = percent. Used when TakeProfit and/or StopLoss are set.
 	LegType      int    `json:"legType,omitempty"`
 	OrderTag     string `json:"orderTag"`
@@ -512,22 +510,30 @@ type ModifyOrderRequest struct {
 	LimitPrice   float64 `json:"limitPrice"`
 	StopPrice    float64 `json:"stopPrice"`
 	DisclosedQty int     `json:"disclosedQty,omitempty"`
-	// TakeProfit is optional. > 0 updates/creates TP; NullOffset()/FloatOffset(0) removes; omit keeps existing.
-	TakeProfit *FloatValue `json:"takeProfit,omitempty"`
-	// StopLoss is optional. > 0 updates/creates SL; NullOffset()/FloatOffset(0) removes; omit keeps existing.
-	StopLoss *FloatValue `json:"stopLoss,omitempty"`
+	// TakeProfit is optional. > 0 updates/creates TP; 0 / omitted keeps existing unless ClearTakeProfit is set.
+	TakeProfit float64 `json:"takeProfit,omitempty"`
+	// StopLoss is optional. > 0 updates/creates SL; 0 / omitted keeps existing unless ClearStopLoss is set.
+	StopLoss float64 `json:"stopLoss,omitempty"`
+	// ClearTakeProfit sends takeProfit as JSON null to remove the TP leg.
+	ClearTakeProfit bool `json:"-"`
+	// ClearStopLoss sends stopLoss as JSON null to remove the SL leg.
+	ClearStopLoss bool `json:"-"`
 	// LegType is optional and read-only once legs exist; cannot change legType of active TP/SL legs.
 	LegType int `json:"legType,omitempty"`
 }
 
 // AttachPositionLegsRequest attaches or updates TP/SL legs on an open position (PATCH /positions).
-// TakeProfit and StopLoss are both optional — set either, both, or neither (with NullOffset to remove).
+// TakeProfit and StopLoss are optional float offsets — set either, both, or neither.
 type AttachPositionLegsRequest struct {
 	PositionID string `json:"positionId"`
-	// TakeProfit is optional. Use FloatOffset(v) to set/update, NullOffset() to remove, omit to keep existing.
-	TakeProfit *FloatValue `json:"takeProfit,omitempty"`
-	// StopLoss is optional. Use FloatOffset(v) to set/update, NullOffset() to remove, omit to keep existing.
-	StopLoss *FloatValue `json:"stopLoss,omitempty"`
+	// TakeProfit is optional. > 0 sets/updates TP; 0 / omitted keeps existing unless ClearTakeProfit is set.
+	TakeProfit float64 `json:"takeProfit,omitempty"`
+	// StopLoss is optional. > 0 sets/updates SL; 0 / omitted keeps existing unless ClearStopLoss is set.
+	StopLoss float64 `json:"stopLoss,omitempty"`
+	// ClearTakeProfit sends takeProfit as JSON null to remove the TP leg.
+	ClearTakeProfit bool `json:"-"`
+	// ClearStopLoss sends stopLoss as JSON null to remove the SL leg.
+	ClearStopLoss bool `json:"-"`
 	// LegType is optional. 1 = points (default), 2 = percent.
 	LegType int `json:"legType,omitempty"`
 	Qty     int `json:"qty,omitempty"`

--- a/models.go
+++ b/models.go
@@ -148,6 +148,9 @@ type OrderBookItem struct {
 	OrderNumStatus    string  `json:"orderNumStatus"`
 	DisclosedQty      int     `json:"disclosedQty"`
 	OrderTag          string  `json:"orderTag"`
+	TakeProfit        float64 `json:"takeProfit,omitempty"`
+	StopLoss          float64 `json:"stopLoss,omitempty"`
+	LegType           int     `json:"legType,omitempty"`
 }
 
 type Position struct {
@@ -186,6 +189,9 @@ type NetPosition struct {
 	DayBuyQty        int     `json:"dayBuyQty"`
 	DaySellQty       int     `json:"daySellQty"`
 	Exchange         int     `json:"exchange"`
+	TakeProfit       float64 `json:"takeProfit,omitempty"`
+	StopLoss         float64 `json:"stopLoss,omitempty"`
+	LegType          int     `json:"legType,omitempty"`
 }
 
 type OverallPosition struct {
@@ -232,10 +238,16 @@ type OrderRequest struct {
 	Validity     string  `json:"validity"`
 	DisclosedQty int     `json:"disclosedQty"`
 	OfflineOrder bool    `json:"offlineOrder"`
-	StopLoss     float64 `json:"stopLoss"`
-	TakeProfit   float64 `json:"takeProfit"`
-	OrderTag     string  `json:"orderTag"`
-	IsSliceOrder bool    `json:"isSliceOrder,omitempty"`
+	// TakeProfit is optional. Offset (points or percent), not an absolute price. Minimum 0.0025.
+	// Omit to place without a TP leg. Use FloatOffset(v) to set.
+	TakeProfit *FloatValue `json:"takeProfit,omitempty"`
+	// StopLoss is optional. Offset (points or percent), not an absolute price. Minimum 0.0025.
+	// Omit to place without an SL leg. Use FloatOffset(v) to set.
+	StopLoss *FloatValue `json:"stopLoss,omitempty"`
+	// LegType is optional. 1 = points (default), 2 = percent. Used when TakeProfit and/or StopLoss are set.
+	LegType      int    `json:"legType,omitempty"`
+	OrderTag     string `json:"orderTag"`
+	IsSliceOrder bool   `json:"isSliceOrder,omitempty"`
 }
 
 type OrderResponse struct {
@@ -500,6 +512,25 @@ type ModifyOrderRequest struct {
 	LimitPrice   float64 `json:"limitPrice"`
 	StopPrice    float64 `json:"stopPrice"`
 	DisclosedQty int     `json:"disclosedQty,omitempty"`
+	// TakeProfit is optional. > 0 updates/creates TP; NullOffset()/FloatOffset(0) removes; omit keeps existing.
+	TakeProfit *FloatValue `json:"takeProfit,omitempty"`
+	// StopLoss is optional. > 0 updates/creates SL; NullOffset()/FloatOffset(0) removes; omit keeps existing.
+	StopLoss *FloatValue `json:"stopLoss,omitempty"`
+	// LegType is optional and read-only once legs exist; cannot change legType of active TP/SL legs.
+	LegType int `json:"legType,omitempty"`
+}
+
+// AttachPositionLegsRequest attaches or updates TP/SL legs on an open position (PATCH /positions).
+// TakeProfit and StopLoss are both optional — set either, both, or neither (with NullOffset to remove).
+type AttachPositionLegsRequest struct {
+	PositionID string `json:"positionId"`
+	// TakeProfit is optional. Use FloatOffset(v) to set/update, NullOffset() to remove, omit to keep existing.
+	TakeProfit *FloatValue `json:"takeProfit,omitempty"`
+	// StopLoss is optional. Use FloatOffset(v) to set/update, NullOffset() to remove, omit to keep existing.
+	StopLoss *FloatValue `json:"stopLoss,omitempty"`
+	// LegType is optional. 1 = points (default), 2 = percent.
+	LegType int `json:"legType,omitempty"`
+	Qty     int `json:"qty,omitempty"`
 }
 
 type ModifyMultiOrderItem struct {

--- a/orders.go
+++ b/orders.go
@@ -7,9 +7,6 @@ import (
 )
 
 func (m *FyersModel) SingleOrderAction(orderRequest OrderRequest) (string, error) {
-	if err := orderRequest.validateTPSL(); err != nil {
-		return "", err
-	}
 	body, err := json.Marshal(orderRequest)
 	if err != nil {
 		return "", fmt.Errorf("marshal order request: %w", err)
@@ -24,11 +21,6 @@ func (m *FyersModel) SingleOrderAction(orderRequest OrderRequest) (string, error
 }
 
 func (m *FyersModel) MultiOrderAction(orderRequests []OrderRequest) (string, error) {
-	for i, req := range orderRequests {
-		if err := req.validateTPSL(); err != nil {
-			return "", fmt.Errorf("order[%d]: %w", i, err)
-		}
-	}
 	body, err := json.Marshal(orderRequests)
 	if err != nil {
 		return "", fmt.Errorf("marshal order requests: %w", err)

--- a/orders.go
+++ b/orders.go
@@ -7,11 +7,16 @@ import (
 )
 
 func (m *FyersModel) SingleOrderAction(orderRequest OrderRequest) (string, error) {
+	if err := orderRequest.validateTPSL(); err != nil {
+		return "", err
+	}
 	body, err := json.Marshal(orderRequest)
 	if err != nil {
 		return "", fmt.Errorf("marshal order request: %w", err)
 	}
-	resp, err := m.httpClient.DoRaw(http.MethodPost, SingleOrderActionURL, body, m.authHeader())
+	headers := m.authHeader()
+	headers.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.DoRaw(http.MethodPost, SingleOrderActionURL, body, headers)
 	if err != nil {
 		return "", err
 	}
@@ -19,11 +24,18 @@ func (m *FyersModel) SingleOrderAction(orderRequest OrderRequest) (string, error
 }
 
 func (m *FyersModel) MultiOrderAction(orderRequests []OrderRequest) (string, error) {
+	for i, req := range orderRequests {
+		if err := req.validateTPSL(); err != nil {
+			return "", fmt.Errorf("order[%d]: %w", i, err)
+		}
+	}
 	body, err := json.Marshal(orderRequests)
 	if err != nil {
 		return "", fmt.Errorf("marshal order requests: %w", err)
 	}
-	resp, err := m.httpClient.DoRaw(http.MethodPost, MultipleOrderActionURL, body, m.authHeader())
+	headers := m.authHeader()
+	headers.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.DoRaw(http.MethodPost, MultipleOrderActionURL, body, headers)
 	if err != nil {
 		return "", err
 	}
@@ -35,7 +47,9 @@ func (m *FyersModel) MultiLegOrderAction(orderRequests []MultiLegOrderRequest) (
 	if err != nil {
 		return "", fmt.Errorf("marshal order requests: %w", err)
 	}
-	resp, err := m.httpClient.DoRaw(http.MethodPost, MultiLegOrderURL, body, m.authHeader())
+	headers := m.authHeader()
+	headers.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.DoRaw(http.MethodPost, MultiLegOrderURL, body, headers)
 	if err != nil {
 		return "", err
 	}

--- a/tpsl.go
+++ b/tpsl.go
@@ -1,24 +1,6 @@
 package fyersgosdk
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
-func validateLegType(legType int) error {
-	if legType != 0 && legType != LegTypePoints && legType != LegTypePercent {
-		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
-	}
-	return nil
-}
-
-func (r OrderRequest) validateTPSL() error {
-	return validateLegType(r.LegType)
-}
-
-func (r ModifyOrderRequest) validateTPSL() error {
-	return validateLegType(r.LegType)
-}
+import "encoding/json"
 
 // MarshalJSON emits takeProfit/stopLoss as null when Clear* flags are set.
 func (r ModifyOrderRequest) MarshalJSON() ([]byte, error) {
@@ -41,13 +23,6 @@ func (r ModifyOrderRequest) MarshalJSON() ([]byte, error) {
 		m["stopLoss"] = nil
 	}
 	return json.Marshal(m)
-}
-
-func (r AttachPositionLegsRequest) validateTPSL() error {
-	if r.PositionID == "" {
-		return fmt.Errorf("positionId is required")
-	}
-	return validateLegType(r.LegType)
 }
 
 // MarshalJSON emits takeProfit/stopLoss as null when Clear* flags are set.

--- a/tpsl.go
+++ b/tpsl.go
@@ -5,117 +5,70 @@ import (
 	"fmt"
 )
 
-// FloatValue represents an optional float that can be omitted, set to a number,
-// or explicitly serialized as JSON null (used to remove TP/SL legs on modify/attach).
-type FloatValue struct {
-	Value float64
-	Null  bool
-}
-
-// FloatOffset returns a FloatValue set to the given offset.
-func FloatOffset(v float64) *FloatValue {
-	return &FloatValue{Value: v}
-}
-
-// NullOffset returns a FloatValue that serializes as JSON null (removes a TP/SL leg).
-func NullOffset() *FloatValue {
-	return &FloatValue{Null: true}
-}
-
-// MarshalJSON serializes the value as a JSON number or null.
-func (f FloatValue) MarshalJSON() ([]byte, error) {
-	if f.Null {
-		return []byte("null"), nil
-	}
-	return json.Marshal(f.Value)
-}
-
-// UnmarshalJSON accepts a JSON number or null.
-func (f *FloatValue) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		f.Null = true
-		f.Value = 0
-		return nil
-	}
-	f.Null = false
-	return json.Unmarshal(data, &f.Value)
-}
-
-func validateProductType(productType string) error {
-	if productType == ProductBO || productType == ProductCO {
-		return fmt.Errorf("BO/CO product types are deprecated (code %d). Use standard product types with takeProfit/stopLoss offsets instead", deprecatedBOCOCode)
+func validateLegType(legType int) error {
+	if legType != 0 && legType != LegTypePoints && legType != LegTypePercent {
+		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
 	}
 	return nil
-}
-
-func validateOffset(name string, value float64, legType int) error {
-	if value < 0 {
-		return fmt.Errorf("takeProfit and stopLoss offsets must be positive numbers")
-	}
-	if value == 0 {
-		return nil
-	}
-	if value < minTPSLOffset {
-		return fmt.Errorf("%s offset must be greater than or equal to %g", name, minTPSLOffset)
-	}
-	if legType == LegTypePercent && value > maxTPSLPercent {
-		return fmt.Errorf("takeProfit/stopLoss percentage must be between %g and %g", minTPSLOffset, maxTPSLPercent)
-	}
-	return nil
-}
-
-func validateOptionalFloatOffset(name string, v *FloatValue, legType int, hasLegType bool) error {
-	if v == nil || v.Null {
-		return nil
-	}
-	effectiveLegType := LegTypePoints
-	if hasLegType {
-		effectiveLegType = legType
-	}
-	if v.Value < 0 {
-		return fmt.Errorf("takeProfit and stopLoss offsets must be positive numbers")
-	}
-	if v.Value == 0 {
-		return nil
-	}
-	return validateOffset(name, v.Value, effectiveLegType)
 }
 
 func (r OrderRequest) validateTPSL() error {
-	if err := validateProductType(r.ProductType); err != nil {
-		return err
-	}
-	hasLegType := r.LegType != 0
-	if hasLegType && r.LegType != LegTypePoints && r.LegType != LegTypePercent {
-		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
-	}
-	if err := validateOptionalFloatOffset("takeProfit", r.TakeProfit, r.LegType, hasLegType); err != nil {
-		return err
-	}
-	return validateOptionalFloatOffset("stopLoss", r.StopLoss, r.LegType, hasLegType)
+	return validateLegType(r.LegType)
 }
 
 func (r ModifyOrderRequest) validateTPSL() error {
-	hasLegType := r.LegType != 0
-	if hasLegType && r.LegType != LegTypePoints && r.LegType != LegTypePercent {
-		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
+	return validateLegType(r.LegType)
+}
+
+// MarshalJSON emits takeProfit/stopLoss as null when Clear* flags are set.
+func (r ModifyOrderRequest) MarshalJSON() ([]byte, error) {
+	type alias ModifyOrderRequest
+	raw, err := json.Marshal(alias(r))
+	if err != nil {
+		return nil, err
 	}
-	if err := validateOptionalFloatOffset("takeProfit", r.TakeProfit, r.LegType, hasLegType); err != nil {
-		return err
+	if !r.ClearTakeProfit && !r.ClearStopLoss {
+		return raw, nil
 	}
-	return validateOptionalFloatOffset("stopLoss", r.StopLoss, r.LegType, hasLegType)
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if r.ClearTakeProfit {
+		m["takeProfit"] = nil
+	}
+	if r.ClearStopLoss {
+		m["stopLoss"] = nil
+	}
+	return json.Marshal(m)
 }
 
 func (r AttachPositionLegsRequest) validateTPSL() error {
 	if r.PositionID == "" {
 		return fmt.Errorf("positionId is required")
 	}
-	hasLegType := r.LegType != 0
-	if hasLegType && r.LegType != LegTypePoints && r.LegType != LegTypePercent {
-		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
+	return validateLegType(r.LegType)
+}
+
+// MarshalJSON emits takeProfit/stopLoss as null when Clear* flags are set.
+func (r AttachPositionLegsRequest) MarshalJSON() ([]byte, error) {
+	type alias AttachPositionLegsRequest
+	raw, err := json.Marshal(alias(r))
+	if err != nil {
+		return nil, err
 	}
-	if err := validateOptionalFloatOffset("takeProfit", r.TakeProfit, r.LegType, hasLegType); err != nil {
-		return err
+	if !r.ClearTakeProfit && !r.ClearStopLoss {
+		return raw, nil
 	}
-	return validateOptionalFloatOffset("stopLoss", r.StopLoss, r.LegType, hasLegType)
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if r.ClearTakeProfit {
+		m["takeProfit"] = nil
+	}
+	if r.ClearStopLoss {
+		m["stopLoss"] = nil
+	}
+	return json.Marshal(m)
 }

--- a/tpsl.go
+++ b/tpsl.go
@@ -1,0 +1,121 @@
+package fyersgosdk
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// FloatValue represents an optional float that can be omitted, set to a number,
+// or explicitly serialized as JSON null (used to remove TP/SL legs on modify/attach).
+type FloatValue struct {
+	Value float64
+	Null  bool
+}
+
+// FloatOffset returns a FloatValue set to the given offset.
+func FloatOffset(v float64) *FloatValue {
+	return &FloatValue{Value: v}
+}
+
+// NullOffset returns a FloatValue that serializes as JSON null (removes a TP/SL leg).
+func NullOffset() *FloatValue {
+	return &FloatValue{Null: true}
+}
+
+// MarshalJSON serializes the value as a JSON number or null.
+func (f FloatValue) MarshalJSON() ([]byte, error) {
+	if f.Null {
+		return []byte("null"), nil
+	}
+	return json.Marshal(f.Value)
+}
+
+// UnmarshalJSON accepts a JSON number or null.
+func (f *FloatValue) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		f.Null = true
+		f.Value = 0
+		return nil
+	}
+	f.Null = false
+	return json.Unmarshal(data, &f.Value)
+}
+
+func validateProductType(productType string) error {
+	if productType == ProductBO || productType == ProductCO {
+		return fmt.Errorf("BO/CO product types are deprecated (code %d). Use standard product types with takeProfit/stopLoss offsets instead", deprecatedBOCOCode)
+	}
+	return nil
+}
+
+func validateOffset(name string, value float64, legType int) error {
+	if value < 0 {
+		return fmt.Errorf("takeProfit and stopLoss offsets must be positive numbers")
+	}
+	if value == 0 {
+		return nil
+	}
+	if value < minTPSLOffset {
+		return fmt.Errorf("%s offset must be greater than or equal to %g", name, minTPSLOffset)
+	}
+	if legType == LegTypePercent && value > maxTPSLPercent {
+		return fmt.Errorf("takeProfit/stopLoss percentage must be between %g and %g", minTPSLOffset, maxTPSLPercent)
+	}
+	return nil
+}
+
+func validateOptionalFloatOffset(name string, v *FloatValue, legType int, hasLegType bool) error {
+	if v == nil || v.Null {
+		return nil
+	}
+	effectiveLegType := LegTypePoints
+	if hasLegType {
+		effectiveLegType = legType
+	}
+	if v.Value < 0 {
+		return fmt.Errorf("takeProfit and stopLoss offsets must be positive numbers")
+	}
+	if v.Value == 0 {
+		return nil
+	}
+	return validateOffset(name, v.Value, effectiveLegType)
+}
+
+func (r OrderRequest) validateTPSL() error {
+	if err := validateProductType(r.ProductType); err != nil {
+		return err
+	}
+	hasLegType := r.LegType != 0
+	if hasLegType && r.LegType != LegTypePoints && r.LegType != LegTypePercent {
+		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
+	}
+	if err := validateOptionalFloatOffset("takeProfit", r.TakeProfit, r.LegType, hasLegType); err != nil {
+		return err
+	}
+	return validateOptionalFloatOffset("stopLoss", r.StopLoss, r.LegType, hasLegType)
+}
+
+func (r ModifyOrderRequest) validateTPSL() error {
+	hasLegType := r.LegType != 0
+	if hasLegType && r.LegType != LegTypePoints && r.LegType != LegTypePercent {
+		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
+	}
+	if err := validateOptionalFloatOffset("takeProfit", r.TakeProfit, r.LegType, hasLegType); err != nil {
+		return err
+	}
+	return validateOptionalFloatOffset("stopLoss", r.StopLoss, r.LegType, hasLegType)
+}
+
+func (r AttachPositionLegsRequest) validateTPSL() error {
+	if r.PositionID == "" {
+		return fmt.Errorf("positionId is required")
+	}
+	hasLegType := r.LegType != 0
+	if hasLegType && r.LegType != LegTypePoints && r.LegType != LegTypePercent {
+		return fmt.Errorf("legType must be 1 (points) or 2 (percent)")
+	}
+	if err := validateOptionalFloatOffset("takeProfit", r.TakeProfit, r.LegType, hasLegType); err != nil {
+		return err
+	}
+	return validateOptionalFloatOffset("stopLoss", r.StopLoss, r.LegType, hasLegType)
+}

--- a/trade_operations.go
+++ b/trade_operations.go
@@ -7,9 +7,6 @@ import (
 )
 
 func (m *FyersModel) ModifyOrder(orderRequest ModifyOrderRequest) (string, error) {
-	if err := orderRequest.validateTPSL(); err != nil {
-		return "", err
-	}
 	body, err := json.Marshal(orderRequest)
 	if err != nil {
 		return "", fmt.Errorf("marshal order request: %w", err)
@@ -140,11 +137,8 @@ func (m *FyersModel) ConvertPosition(req ConvertPositionRequest) (string, error)
 }
 
 // AttachPositionLegs attaches or updates TP/SL legs on an open position (PATCH /positions).
-// Use NullOffset() to remove a leg; omit TakeProfit/StopLoss to leave the existing leg unchanged.
+// Use ClearTakeProfit/ClearStopLoss to remove a leg; omit TakeProfit/StopLoss (leave 0) to keep existing.
 func (m *FyersModel) AttachPositionLegs(req AttachPositionLegsRequest) (string, error) {
-	if err := req.validateTPSL(); err != nil {
-		return "", err
-	}
 	body, err := json.Marshal(req)
 	if err != nil {
 		return "", fmt.Errorf("marshal attach position legs request: %w", err)

--- a/trade_operations.go
+++ b/trade_operations.go
@@ -7,11 +7,16 @@ import (
 )
 
 func (m *FyersModel) ModifyOrder(orderRequest ModifyOrderRequest) (string, error) {
+	if err := orderRequest.validateTPSL(); err != nil {
+		return "", err
+	}
 	body, err := json.Marshal(orderRequest)
 	if err != nil {
 		return "", fmt.Errorf("marshal order request: %w", err)
 	}
-	resp, err := m.httpClient.DoRaw(http.MethodPatch, SingleOrderActionURL, body, m.authHeader())
+	headers := m.authHeader()
+	headers.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.DoRaw(http.MethodPatch, SingleOrderActionURL, body, headers)
 	if err != nil {
 		return "", err
 	}
@@ -128,6 +133,25 @@ func (m *FyersModel) ConvertPosition(req ConvertPositionRequest) (string, error)
 	headers := m.authHeader()
 	headers.Set("Content-Type", "application/json")
 	resp, err := m.httpClient.DoRaw(http.MethodPost, PositionURL, body, headers)
+	if err != nil {
+		return "", err
+	}
+	return string(resp.Body), nil
+}
+
+// AttachPositionLegs attaches or updates TP/SL legs on an open position (PATCH /positions).
+// Use NullOffset() to remove a leg; omit TakeProfit/StopLoss to leave the existing leg unchanged.
+func (m *FyersModel) AttachPositionLegs(req AttachPositionLegsRequest) (string, error) {
+	if err := req.validateTPSL(); err != nil {
+		return "", err
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("marshal attach position legs request: %w", err)
+	}
+	headers := m.authHeader()
+	headers.Set("Content-Type", "application/json")
+	resp, err := m.httpClient.DoRaw(http.MethodPatch, PositionURL, body, headers)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live order placement, modification, and position PATCH payloads for trading flows; incorrect TP/SL or null-clear semantics could cause unintended API behavior, though scope is additive with documented offset semantics.
> 
> **Overview**
> Bumps the SDK to **v1.5.0** and documents **TP/SL smart orders** as offset-based legs (points or percent), replacing deprecated **`BO`/`CO`** product flows.
> 
> **Order and position APIs** gain optional `takeProfit`, `stopLoss`, and `legType` on place (`OrderRequest`), modify (`ModifyOrderRequest` with `ClearTakeProfit` / `ClearStopLoss` for JSON `null`), and a new **`AttachPositionLegs`** PATCH on positions. Custom `MarshalJSON` in `tpsl.go` ensures cleared legs serialize as `null`. Response models for orders and net positions include the new TP/SL fields.
> 
> Adds **`constants.go`** (`ProductCNC`, `ProductIntraday`, `LegTypePoints`, `LegTypePercent`). Order placement and modify paths now set **`Content-Type: application/json`** on POST/PATCH. Examples and README are expanded for TP/SL; sample credentials in `examples/fyers/fyers.go` are sanitized and the live option-chain `main` is commented out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3abded9e1f40a1a2e67f4a3d9f6edba461595c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->